### PR TITLE
fix(bee-agent): rendering of empty lines in prompt

### DIFF
--- a/src/agents/bee/prompts.ts
+++ b/src/agents/bee/prompts.ts
@@ -35,13 +35,14 @@ Tool Input: {"id":178}
 
 ## Available tools
 {{#tools}}
+
 Tool Name: {{name}}
 Tool Description: {{description}}
 Tool Input Schema: {{schema}}
-
 {{/tools}}
 {{/tools.length}}
 {{^tools.length}}
+
 ## Available tools
 
 No tools are available at the moment therefore you mustn't provide any factual or historical information.
@@ -78,6 +79,7 @@ Responses must always have the following structure:
   - When the problem seems too hard for the tool, the assistant tries to split the problem into a few smaller ones.
 
 ## Notes
+
 - Any comparison table (including its content), file, image, link, or other asset must only be in the Final Answer.
 - When the question is unclear, respond with a line starting with 'Final Answer:' followed by the information needed to solve the problem.
 - When the user wants to chitchat instead, always respond politely.


### PR DESCRIPTION
### Description

In certain scenarios, the underlying prompt template used to render empty lines in places where it wasn't expected.

Attaching test cases:
![Screenshot 2024-09-09 at 16 06 42](https://github.com/user-attachments/assets/620d89a8-cc5a-4e74-858b-8d6529083898)
![Screenshot 2024-09-09 at 16 07 47](https://github.com/user-attachments/assets/13fd314e-9dc0-4297-8ecf-35cc957583c8)
![Screenshot 2024-09-09 at 16 08 07](https://github.com/user-attachments/assets/fa703bba-8978-4ddd-97e2-cda9e6c78a82)

