### PR TITLE
fix(llama-3-1): add trailing new line

### DIFF
--- a/src/adapters/shared/llmChatTemplates.ts
+++ b/src/adapters/shared/llmChatTemplates.ts
@@ -70,6 +70,7 @@ const llama31: LLMChatTemplate = {
 {{assistant}}<|eot_id|>{{/assistant}}{{#ipython}}<|start_header_id|>ipython<|end_header_id|>
 
 {{ipython}}<|eot_id|>{{/ipython}}{{/messages}}<|start_header_id|>assistant<|end_header_id|>
+
 `,
   }),
   messagesToPrompt: messagesToPromptFactory({ ipython: "ipython" }),


### PR DESCRIPTION
### Description

It seems like the official llama 3.1 implementation ends the prompt with `\n\n` before passing it for inference. Currently only single `\n` is passed. This has an effect on the inference output.

Supporting evidence:
- https://github.com/meta-llama/llama-models/blob/659a13ae2099748d23088fbf9293521de569dd8c/models/llama3/api/chat_format.py#L29
- https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-prompt-samples.html?context=wx#sample7a0
- https://huggingface.co/meta-llama/Meta-Llama-3.1-70B-Instruct/blob/main/tokenizer_config.json