### PR TITLE
chore: change copyright.sh to be friendlier

### DIFF
--- a/scripts/copyright.sh
+++ b/scripts/copyright.sh
@@ -24,15 +24,6 @@ if [[ ! -f "$PACKAGE_JSON_PATH" ]]; then
   exit 1
 fi
 
-# Retrieve the author property using jq
-AUTHOR=$(jq -r '.author' "$PACKAGE_JSON_PATH")
-
-# Check if the author property is not null or empty
-if [[ -z "$AUTHOR" ]]; then
-  echo "Error: author property not found in package.json"
-  exit 1
-fi
-
 # Check if 'nwa' command is not available and 'go' is available, then install 'nwa'
 if ! command -v nwa &> /dev/null && command -v go &> /dev/null; then
   echo "Installing 'nwa' via 'go' (https://github.com/B1NARY-GR0UP/nwa)"
@@ -41,10 +32,14 @@ if ! command -v nwa &> /dev/null && command -v go &> /dev/null; then
   export PATH=$PATH:$(go env GOPATH)/bin
 fi
 
+# Use open source project friendly copyright.
+# Use one-line SPDX-ID for Apache-2.0.
+AUTHOR="The Bee Authors."
+
 if command -v nwa &> /dev/null; then
-  nwa add -l apache -c "$AUTHOR" src dist tests scripts
+  nwa add -i Apache-2.0 -c "$AUTHOR" src dist tests scripts
 elif command -v docker &> /dev/null; then
-  docker run -it -v "${PWD}:/src" ghcr.io/b1nary-gr0up/nwa:main add -l apache -c "$AUTHOR" src dist tests scripts
+  docker run -it -v "${PWD}:/src" ghcr.io/b1nary-gr0up/nwa:main add -i Apache-2.0 -c "$AUTHOR" src dist tests scripts
 else
   echo "Error: 'nwa' is not available. Either install it manually or install go/docker."
   exit 1


### PR DESCRIPTION


### Which issue(s) does this pull-request address?

Closes: #30

### Description

* Use open source project authors instead of company name in copyright.
  - New files only. No existing copyright changes in this commit.
* Use the SPDXID one-line form of Apache-2.0 instead of text blob.
  - Takes less space and is less likely to introduce license change creep.
* Remove the need for "jq" which is not documented as a project pre-req.

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [ ] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
