### PR TITLE
feat(code-interpreter): rename "hash" to "pythonId"

### DIFF
--- a/src/tools/python/python.ts
+++ b/src/tools/python/python.ts
@@ -191,7 +191,7 @@ export class PythonTool extends Tool<PythonToolOutput, PythonToolOptions> {
         sourceCode: await getSourceCode(),
         executorId: this.options.executorId ?? "default",
         files: Object.fromEntries(
-          inputFiles.map((file) => [`${prefix}${file.filename}`, file.hash]),
+          inputFiles.map((file) => [`${prefix}${file.filename}`, file.pythonId]),
         ),
       },
       { signal: run.signal },
@@ -203,18 +203,22 @@ export class PythonTool extends Tool<PythonToolOutput, PythonToolOptions> {
     const filesOutput = await this.storage.download(
       Object.entries(result.files)
         .map(([k, v]) => {
-          const file = { path: k, hash: v };
+          const file = { path: k, pythonId: v };
           if (!file.path.startsWith(prefix)) {
             return;
           }
 
           const filename = file.path.slice(prefix.length);
-          if (inputFiles.some((input) => input.filename === filename && input.hash === file.hash)) {
+          if (
+            inputFiles.some(
+              (input) => input.filename === filename && input.pythonId === file.pythonId,
+            )
+          ) {
             return;
           }
 
           return {
-            hash: file.hash,
+            pythonId: file.pythonId,
             filename,
           };
         })

--- a/src/tools/python/storage.ts
+++ b/src/tools/python/storage.ts
@@ -26,7 +26,7 @@ import { shallowCopy } from "@/serializer/utils.js";
 
 export interface PythonFile {
   id: string;
-  hash: string;
+  pythonId: string;
   filename: string;
 }
 
@@ -38,7 +38,7 @@ export interface PythonUploadFile {
 export interface PythonDownloadFile {
   id?: string;
   filename: string;
-  hash: string;
+  pythonId: string;
 }
 
 export abstract class PythonStorage extends Serializable {
@@ -68,7 +68,7 @@ export class TemporaryStorage extends PythonStorage {
   async upload(files: PythonUploadFile[]): Promise<PythonFile[]> {
     return files.map((file) => ({
       id: file.id,
-      hash: file.id,
+      pythonId: file.id,
       filename: file.filename,
     }));
   }
@@ -76,7 +76,7 @@ export class TemporaryStorage extends PythonStorage {
   async download(files: PythonDownloadFile[]) {
     this.files = [
       ...this.files.filter((file) => files.every((f) => f.filename !== file.filename)),
-      ...files.map((file) => ({ id: file.hash, ...file })),
+      ...files.map((file) => ({ id: file.pythonId, ...file })),
     ];
     return this.files.slice();
   }
@@ -124,14 +124,14 @@ export class LocalPythonStorage extends PythonStorage {
       files
         .filter((file) => file.isFile() && !this.input.ignoredFiles.has(file.name))
         .map(async (file) => {
-          const hash = await this.computeHash(
+          const pythonId = await this.computeHash(
             path.join(this.input.localWorkingDir.toString(), file.name),
           );
 
           return {
-            id: hash,
+            id: pythonId,
             filename: file.name,
-            hash,
+            pythonId,
           };
         }),
     );
@@ -151,7 +151,7 @@ export class LocalPythonStorage extends PythonStorage {
         );
       }),
     );
-    return files.map((file) => ({ ...file, hash: file.id }));
+    return files.map((file) => ({ ...file, pythonId: file.id }));
   }
 
   async download(files: PythonDownloadFile[]) {
@@ -160,12 +160,12 @@ export class LocalPythonStorage extends PythonStorage {
     await Promise.all(
       files.map((file) =>
         copyFile(
-          path.join(this.input.interpreterWorkingDir.toString(), file.hash),
+          path.join(this.input.interpreterWorkingDir.toString(), file.pythonId),
           path.join(this.input.localWorkingDir.toString(), file.filename),
         ),
       ),
     );
-    return files.map((file) => ({ ...file, id: file.hash }));
+    return files.map((file) => ({ ...file, id: file.pythonId }));
   }
 
   protected async computeHash(file: PathLike) {


### PR DESCRIPTION
Rename `hash` to signify that we no longer require this to be a content hash of the file.