### PR TITLE
doc: fixup a few links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The Bee Agent Framework makes it easy to build scalable agent-based workflows wi
 - 🛠️ **Tools**: Use our [built-in tools](./docs/tools.md) or [create your own](./docs/tools.md) in Javascript/Python.
 - 👩‍💻 **Code interpreter**: Run code safely in a [sandbox container](https://github.com/i-am-bee/bee-code-interpreter).
 - 💾 **Memory**: Multiple [strategies](./docs/memory.md) to optimize token spend.
-- ⏸️ **Serialization** Handle complex agentic workflows and easily pause/resume them [without losing state](https://github.com/i-am-bee/bee-agent-framework/blob/main/docs/overview.md#serializer).
-- 🔍 **Traceability**: Get full visibility of your agent’s inner workings, [log](https://github.com/i-am-bee/bee-agent-framework/blob/main/docs/overview.md#logger) all running events, and use our MLFlow integration (coming out next week) to debug performance.
+- ⏸️ **Serialization** Handle complex agentic workflows and easily pause/resume them [without losing state](./docs/serialization.md).
+- 🔍 **Traceability**: Get full visibility of your agent’s inner workings, [log](./docs/logger.md) all running events, and use our MLFlow integration (coming out next week) to debug performance.
 - 🎛️ **Production-level** control with [caching](./docs/cache.md) and [error handling](./docs/errors.md).
 - 🚧 (Coming soon) **API**: Configure and deploy your agents with a production-hardened API.
 - 🚧 (Coming soon) **Chat UI**: Serve your agent to users in a delightful GUI with built-in transparency, explainability, and user controls.


### PR DESCRIPTION
Some links still went to old overview page, update links to point to specific pages to be consistent with references to other pages moved from the overview page and references to the same topic elsewhere in the README.md

<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

Noticed a few links that still went to the overview that now just has entries pointing to specific pages.
Other references in the README.md to the same topics already pointed to the specific pages so update
to be consistent with that.

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

Updated links to point to the specific pages.

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [X] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [X] Linting passes: `yarn lint` or `yarn lint:fix`
- [X] Formatting is applied: `yarn format` or `yarn format:fix`
- [X] Unit tests pass: `yarn test:unit`
- [X] E2E tests pass: `yarn test:e2e`
- [X] Tests are included <!-- Bug fixes and new features should include tests -->
- [X] Documentation is changed or added
- [X] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
