### PR TITLE
chore: support local model for running e2e tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,12 +61,13 @@ yarn install
 5.  **Setup environmental variables:** To run E2E Tests, you should set the following variables in your `.env` file in the repository’s root.
 
 ```bash
-# At least one provider API key must be defined!
+# At least one provider API key or an OLLAMA_HOST must be defined!
 GENAI_API_KEY=""
 OPENAI_API_KEY=""
 GROQ_API_KEY=""
 WATSONX_API_KEY=""
 WATSONX_PROJECT_ID=""
+OLLAMA_HOST=""
 
 WATSONX_SPACE_ID="" # optional
 WATSONX_DEPLOYMENT_ID=""  # optional


### PR DESCRIPTION
Add support for using a local model for e2e testing.

<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

Currently e2e testing requires a remote service which may cost people $ to run. Add the option
to use a model running locally if OLLAMA_HOST is set. If an API key is specified the associated
service will be used in preference to OLLAMA_HOST so this change should have no effect on
people not trying to use a local model.

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

If OLLAMA_HOST is set and no other API keys are providced use that host to run the e2e tests.

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [X] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [X] Linting passes: `yarn lint` or `yarn lint:fix`
- [X] Formatting is applied: `yarn format` or `yarn format:fix`
- [X] Unit tests pass: `yarn test:unit`
- [X] E2E tests pass: `yarn test:e2e`
- [X] Tests are included <!-- Bug fixes and new features should include tests -->
- [X] Documentation is changed or added
- [X] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
