### PR TITLE
docs: fix typos in 6 md files in docs folder (#115)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -119,11 +119,11 @@
 
 ### Features
 
-- **agent:** add fallback for invalid llm output ([5ac89c1](https://github.com/i-am-bee/bee-agent-framework/commit/5ac89c15fce25ce78698fd5a9b80437de0af5e88)), closes [#55](https://github.com/i-am-bee/bee-agent-framework/issues/55)
+- **agent:** add fallback for invalid LLM output ([5ac89c1](https://github.com/i-am-bee/bee-agent-framework/commit/5ac89c15fce25ce78698fd5a9b80437de0af5e88)), closes [#55](https://github.com/i-am-bee/bee-agent-framework/issues/55)
 - **agent:** improve LinePrefixParser error messages ([710f75b](https://github.com/i-am-bee/bee-agent-framework/commit/710f75b0f6cc5a4ba73c2ad0719bc3e359b690f1))
 - **agent:** update bee system prompt ([#56](https://github.com/i-am-bee/bee-agent-framework/issues/56)) ([08c4714](https://github.com/i-am-bee/bee-agent-framework/commit/08c471451ac574ad4598e87157aeb8987477bb33))
 - **agent:** update bee system prompt ([#58](https://github.com/i-am-bee/bee-agent-framework/issues/58)) ([572572b](https://github.com/i-am-bee/bee-agent-framework/commit/572572b903704a5bf983e5508a1c5143238b8254)), closes [#55](https://github.com/i-am-bee/bee-agent-framework/issues/55)
-- **tools:** improve wikipedia parsing ([#57](https://github.com/i-am-bee/bee-agent-framework/issues/57)) ([513572f](https://github.com/i-am-bee/bee-agent-framework/commit/513572f4627f8e96ce917c8998ae1813ee4fe119))
+- **tools:** improve Wikipedia parsing ([#57](https://github.com/i-am-bee/bee-agent-framework/issues/57)) ([513572f](https://github.com/i-am-bee/bee-agent-framework/commit/513572f4627f8e96ce917c8998ae1813ee4fe119))
 
 ### Bug Fixes
 

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -73,4 +73,4 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -146,7 +146,7 @@ We automatically verify that all commit messages contain a `Signed-off-by:` line
 
 There are a number of tools that make it easier for developers to manage DCO signoffs.
 
-- DCO command line tool, which let's you do a single signoff for an entire repo ( <https://github.com/coderanger/dco> )
+- DCO command line tool, which lets you do a single signoff for an entire repo ( <https://github.com/coderanger/dco> )
 - GitHub UI integrations for adding the signoff automatically ( <https://github.com/scottrigby/dco-gh-ui> )
 - Chrome - <https://chrome.google.com/webstore/detail/dco-github-ui/onhgmjhnaeipfgacbglaphlmllkpoijo>
 - Firefox - <https://addons.mozilla.org/en-US/firefox/addon/scott-rigby/?src=search>

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -11,7 +11,7 @@ An agent can be thought of as a program powered by LLM. The LLM generates struct
 Your program then decides what to do next based on the retrieved content. It may leverage a tool, reflect, or produce a final answer.
 Before the agent determines the final answer, it performs a series of `steps`. A step might be calling an LLM, parsing the LLM output, or calling a tool.
 
-Steps are grouped in an `iteration`, and every update (either complete or partial) is emitted to the user.
+Steps are grouped in a `iteration`, and every update (either complete or partial) is emitted to the user.
 
 ### Bee Agent
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -161,7 +161,7 @@ import { SlidingCache } from "bee-agent-framework/cache/slidingCache";
 
 const cache = new SlidingCache<number>({
   size: 3, // (required) number of items that can be live in the cache at a single moment
-  ttl: 1000, // (optional, default is Infinity) Time in miliseconds after the element is removed from a cache
+  ttl: 1000, // (optional, default is Infinity) Time in milliseconds after the element is removed from a cache
 });
 
 await cache.set("a", 1);

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,7 +16,7 @@ The source directory (`src`) provides numerous modules that one can use.
 | [**adapters**](./llms.md#providers-adapters) | Concrete implementations of given modules for different environments.                       |
 | [**logger**](./logger.md)                    | Core component for logging all actions within the framework.                                |
 | [**serializer**](./serialization.md)         | Core component for the ability to serialize/deserialize modules into the serialized format. |
-| [**version**](./version.md)                  | Constants representing the framework (e.g., latest version)                                 |
+| [**version**](./version.md)                  | Constants representing the framework (e.g., the latest version)                                 |
 | [**emitter**](./emitter.md)                  | Bringing visibility to the system by emitting events.                                       |
 | **internals**                                | Modules used by other modules within the framework.                                         |
 


### PR DESCRIPTION
Fix typos in CHANGELOG.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, agents.md, cache.md, and overview.md

Also fixed a link at the end of CODE_OF_CONDUCT.md to make it clickable

### Which issue(s) does this pull-request address?

Closes: #115

### Description

- [x] Fixing typos
    - CHANGELOG.md
    - CODE_OF_CONDUCT.md
    - CONTRIBUTING.md
    - agents.md
    - cache.md
    - overview.md
- [x] your creative ideas
    - CODE_OF_CONDUCT.md changed simple link to markdown link
    i.e. from "https://www.contributor-covenant.org/faq" to "[www.contributor-covenant.org/faq](https://www.contributor covenant.org/faq)"

### Checklist

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [x] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
