### PR TITLE
Update the granite chat template for tools

### DIFF
--- a/src/adapters/ibm-vllm/chatPreset.ts
+++ b/src/adapters/ibm-vllm/chatPreset.ts
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-import { LLMChatTemplate, LLMChatTemplates } from "@/adapters/shared/llmChatTemplates.js";
-import { z } from "zod";
-
+import { LLMChatTemplates } from "@/adapters/shared/llmChatTemplates.js";
 import { IBMVllmInputConfig } from "./chat.js";
 import { IBMvLLMInput } from "./llm.js";
-
-import { PromptTemplate } from "@/template.js";
 
 interface IBMVllmChatLLMPreset {
   chat: IBMVllmInputConfig;

--- a/src/adapters/ibm-vllm/chatPreset.ts
+++ b/src/adapters/ibm-vllm/chatPreset.ts
@@ -100,35 +100,7 @@ export const IBMVllmChatLLMPreset = {
     };
   },
   [IBMVllmModel.GRANITE_INSTRUCT]: (): IBMVllmChatLLMPreset => {
-    const llama31config = LLMChatTemplates.get("llama3.1");
-    const { template, parameters, messagesToPrompt } = {
-      template: new PromptTemplate({
-        schema: z.object({
-          messages: z.array(
-            z.object({
-              system: z.array(z.string()),
-              user: z.array(z.string()),
-              assistant: z.array(z.string()),
-              ipython: z.array(z.string()),
-            }),
-          ),
-        }),
-        template: `{{#messages}}{{#system}}<|start_of_role|>system<|end_of_role|>
-    
-    {{system}}<|end_of_text|>{{/system}}{{#user}}<|start_of_role|>user<|end_of_role|>
-    
-    {{user}}<|end_of_text|>{{/user}}{{#assistant}}<|start_of_role|>assistant<|end_of_role|>
-    
-    {{assistant}}<|end_of_text|>{{/assistant}}{{#ipython}}<|start_of_role|>ipython<|end_of_role|>
-    
-    {{ipython}}<|end_of_text|>{{/ipython}}{{/messages}}<|start_of_role|>assistant<|end_of_role|>
-    `,
-      }),
-      messagesToPrompt: llama31config.messagesToPrompt,
-      parameters: {
-        stop_sequence: ["<|end_of_text|>"],
-      },
-    } satisfies LLMChatTemplate;
+    const { template, parameters, messagesToPrompt } = LLMChatTemplates.get("granite3Instruct");
     return {
       base: {
         modelId: IBMVllmModel.GRANITE_INSTRUCT,

--- a/src/adapters/shared/llmChatTemplates.ts
+++ b/src/adapters/shared/llmChatTemplates.ts
@@ -172,7 +172,7 @@ export class LLMChatTemplates {
     "llama3.1": llama31,
     "llama3": llama3,
     "qwen2": qwen2,
-    "granite3Instruct": granite3Instruct
+    "granite3Instruct": granite3Instruct,
   };
 
   static register(model: string, template: LLMChatTemplate, override = false) {

--- a/src/adapters/shared/llmChatTemplates.ts
+++ b/src/adapters/shared/llmChatTemplates.ts
@@ -132,11 +132,47 @@ const qwen2: LLMChatTemplate = {
   },
 };
 
+const granite3Instruct: LLMChatTemplate = {
+  template: new PromptTemplate({
+    schema: templateSchemaFactory([
+      "system",
+      "user",
+      "assistant",
+      "available_tools",
+      "tool_call",
+      "tool_response",
+    ] as const),
+    template: `{{#messages}}{{#system}}<|start_of_role|>system<|end_of_role|>
+{{system}}<|end_of_text|>
+{{ end }}{{/system}}{{#available_tools}}<|start_of_role|>available_tools<|end_of_role|>
+{{available_tools}}<|end_of_text|>
+{{ end }}{{/available_tools}}{{#user}}<|start_of_role|>user<|end_of_role|>
+{{user}}<|end_of_text|>
+{{ end }}{{/user}}{{#assistant}}<|start_of_role|>assistant<|end_of_role|>
+{{assistant}}<|end_of_text|>
+{{ end }}{{/assistant}}{{#tool_call}}<|start_of_role|>assistant<|end_of_role|><|tool_call|>
+{{tool_call}}<|end_of_text|>
+{{ end }}{{/tool_call}}{{#tool_response}}<|start_of_role|>tool_response<|end_of_role|>
+{{tool_response}}<|end_of_text|>
+{{ end }}{{/tool_response}}{{/messages}}<|start_of_role|>assistant<|end_of_role|>
+`,
+  }),
+  messagesToPrompt: messagesToPromptFactory({
+    available_tools: "available_tools",
+    tool_response: "tool_response",
+    tool_call: "tool_call",
+  }),
+  parameters: {
+    stop_sequence: ["<|end_of_text|>"],
+  },
+};
+
 export class LLMChatTemplates {
   protected static readonly registry = {
     "llama3.1": llama31,
     "llama3": llama3,
     "qwen2": qwen2,
+    "granite3Instruct": granite3Instruct
   };
 
   static register(model: string, template: LLMChatTemplate, override = false) {


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Update the granite 3 shared chat template to support tool messages. 
Reference: https://huggingface.co/ibm-granite/granite-3.0-8b-instruct/blob/main/tokenizer_config.json
This update paves the way for better granite bee support. 

### Description

1. Move the granite chat template to shared folder. 
2. Update the template with tool roles

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
