### PR TITLE
fix(adapters): remove duplicated function definitions in interfaces

### DIFF
--- a/src/adapters/ibm-vllm/types.ts
+++ b/src/adapters/ibm-vllm/types.ts
@@ -338,26 +338,6 @@ export interface SingleGenerationRequest__Output {
 }
 
 export interface GenerationServiceClient extends grpc.Client {
-  Generate(
-    argument: BatchedGenerationRequest,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<BatchedGenerationResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  Generate(
-    argument: BatchedGenerationRequest,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<BatchedGenerationResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  Generate(
-    argument: BatchedGenerationRequest,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<BatchedGenerationResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  Generate(
-    argument: BatchedGenerationRequest,
-    callback: grpc.requestCallback<BatchedGenerationResponse__Output>,
-  ): grpc.ClientUnaryCall;
   generate(
     argument: BatchedGenerationRequest,
     metadata: grpc.Metadata,
@@ -378,15 +358,6 @@ export interface GenerationServiceClient extends grpc.Client {
     argument: BatchedGenerationRequest,
     callback: grpc.requestCallback<BatchedGenerationResponse__Output>,
   ): grpc.ClientUnaryCall;
-  GenerateStream(
-    argument: SingleGenerationRequest,
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientReadableStream<GenerationResponse__Output>;
-  GenerateStream(
-    argument: SingleGenerationRequest,
-    options?: grpc.CallOptions,
-  ): grpc.ClientReadableStream<GenerationResponse__Output>;
   generateStream(
     argument: SingleGenerationRequest,
     metadata: grpc.Metadata,
@@ -396,26 +367,6 @@ export interface GenerationServiceClient extends grpc.Client {
     argument: SingleGenerationRequest,
     options?: grpc.CallOptions,
   ): grpc.ClientReadableStream<GenerationResponse__Output>;
-  ModelInfo(
-    argument: ModelInfoRequest,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<ModelInfoResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  ModelInfo(
-    argument: ModelInfoRequest,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<ModelInfoResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  ModelInfo(
-    argument: ModelInfoRequest,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<ModelInfoResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  ModelInfo(
-    argument: ModelInfoRequest,
-    callback: grpc.requestCallback<ModelInfoResponse__Output>,
-  ): grpc.ClientUnaryCall;
   modelInfo(
     argument: ModelInfoRequest,
     metadata: grpc.Metadata,
@@ -435,26 +386,6 @@ export interface GenerationServiceClient extends grpc.Client {
   modelInfo(
     argument: ModelInfoRequest,
     callback: grpc.requestCallback<ModelInfoResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  Tokenize(
-    argument: BatchedTokenizeRequest,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<BatchedTokenizeResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  Tokenize(
-    argument: BatchedTokenizeRequest,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<BatchedTokenizeResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  Tokenize(
-    argument: BatchedTokenizeRequest,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<BatchedTokenizeResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  Tokenize(
-    argument: BatchedTokenizeRequest,
-    callback: grpc.requestCallback<BatchedTokenizeResponse__Output>,
   ): grpc.ClientUnaryCall;
   tokenize(
     argument: BatchedTokenizeRequest,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?
No issue opened.

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

There are duplicated function definitions in interfaces in adapters/ibm-vllm/types.ts.  This PR remove them.

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [ ] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
