### PR TITLE
fix(agents): allow override granite bee prompts

### DIFF
--- a/src/agents/granite/agent.ts
+++ b/src/agents/granite/agent.ts
@@ -29,8 +29,8 @@ export class GraniteBeeAgent extends BeeAgent {
       ...input,
       templates: {
         ...input.templates,
-        system: GraniteBeeSystemPrompt,
-        assistant: GraniteBeeAssistantPrompt,
+        system: input.templates?.system ?? GraniteBeeSystemPrompt,
+        assistant: input.templates?.assistant ?? GraniteBeeAssistantPrompt,
       },
     });
   }


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Cant override the GraniteBeeAgent system prompt. 

### Description

Allows overriding of the granite agent system and assistant prompt. Useful for testing/experimentation with system prompt variations. 

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
