### PR TITLE
feat(tools)!: improve type support for events

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -127,6 +127,7 @@ The recommended and most sustainable way to create a tool is by implementing the
 
 ```ts
 import {
+  CustomToolEmitter,
   StringToolOutput,
   Tool,
   ToolInput,
@@ -134,10 +135,17 @@ import {
 } from "bee-agent-framework/tools/base";
 import { z } from "zod";
 import { randomInteger } from "remeda";
+import { Emitter } from "bee-agent-framework/emitter/emitter";
 
 export class RiddleTool extends Tool<StringToolOutput> {
   name = "Riddle";
   description = "It generates a random puzzle to test your knowledge.";
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, StringToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "riddle"],
+      creator: this,
+    });
 
   inputSchema() {
     return z.object({
@@ -200,10 +208,12 @@ import {
   ToolInput,
   JSONToolOutput,
   ToolError,
+  CustomToolEmitter,
 } from "bee-agent-framework/tools/base";
 import { z } from "zod";
 import { createURLParams } from "bee-agent-framework/internals/fetcher";
 import { RunContext } from "bee-agent-framework/context";
+import { Emitter } from "bee-agent-framework/emitter/emitter";
 
 type ToolOptions = BaseToolOptions & { maxResults?: number };
 type ToolRunOptions = BaseToolRunOptions;
@@ -241,6 +251,12 @@ export class OpenLibraryTool extends Tool<OpenLibraryToolOutput, ToolOptions, To
       })
       .partial();
   }
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, OpenLibraryToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "search", "openLibrary"],
+      creator: this,
+    });
 
   static {
     this.register();

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -212,8 +212,8 @@ import {
 } from "bee-agent-framework/tools/base";
 import { z } from "zod";
 import { createURLParams } from "bee-agent-framework/internals/fetcher";
-import { RunContext } from "bee-agent-framework/context";
-import { Emitter } from "bee-agent-framework/emitter/emitter";
+import { GetRunContext } from "bee-agent-framework/context";
+import { Callback, Emitter } from "bee-agent-framework/emitter/emitter";
 
 type ToolOptions = BaseToolOptions & { maxResults?: number };
 type ToolRunOptions = BaseToolRunOptions;
@@ -252,11 +252,17 @@ export class OpenLibraryTool extends Tool<OpenLibraryToolOutput, ToolOptions, To
       .partial();
   }
 
-  public readonly emitter: CustomToolEmitter<ToolInput<this>, OpenLibraryToolOutput> =
-    Emitter.root.child({
-      namespace: ["tool", "search", "openLibrary"],
-      creator: this,
-    });
+  public readonly emitter: CustomToolEmitter<
+    ToolInput<this>,
+    OpenLibraryToolOutput,
+    {
+      beforeFetch: Callback<{ request: { url: string; options: RequestInit } }>;
+      afterFetch: Callback<{ data: OpenLibraryResponse }>;
+    }
+  > = Emitter.root.child({
+    namespace: ["tool", "search", "openLibrary"],
+    creator: this,
+  });
 
   static {
     this.register();
@@ -265,14 +271,17 @@ export class OpenLibraryTool extends Tool<OpenLibraryToolOutput, ToolOptions, To
   protected async _run(
     input: ToolInput<this>,
     _options: ToolRunOptions | undefined,
-    run: RunContext<this>,
+    run: GetRunContext<this>,
   ) {
-    const query = createURLParams({
-      searchon: input,
-    });
-    const response = await fetch(`https://openlibrary.org?${query}`, {
-      signal: run.signal,
-    });
+    const request = {
+      url: `https://openlibrary.org?${createURLParams({
+        searchon: input,
+      })}`,
+      options: { signal: run.signal } as RequestInit,
+    };
+
+    await run.emitter.emit("beforeFetch", { request });
+    const response = await fetch(request.url, request.options);
 
     if (!response.ok) {
       throw new ToolError(
@@ -289,6 +298,7 @@ export class OpenLibraryTool extends Tool<OpenLibraryToolOutput, ToolOptions, To
       json.docs.length = this.options.maxResults;
     }
 
+    await run.emitter.emit("afterFetch", { data: json });
     return new OpenLibraryToolOutput(json);
   }
 }

--- a/examples/tools/custom/base.ts
+++ b/examples/tools/custom/base.ts
@@ -1,4 +1,5 @@
 import {
+  CustomToolEmitter,
   StringToolOutput,
   Tool,
   ToolInput,
@@ -6,10 +7,17 @@ import {
 } from "bee-agent-framework/tools/base";
 import { z } from "zod";
 import { randomInteger } from "remeda";
+import { Emitter } from "bee-agent-framework/emitter/emitter";
 
 export class RiddleTool extends Tool<StringToolOutput> {
   name = "Riddle";
   description = "It generates a random puzzle to test your knowledge.";
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, StringToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "riddle"],
+      creator: this,
+    });
 
   inputSchema() {
     return z.object({

--- a/examples/tools/custom/openLibrary.ts
+++ b/examples/tools/custom/openLibrary.ts
@@ -5,10 +5,12 @@ import {
   ToolInput,
   JSONToolOutput,
   ToolError,
+  CustomToolEmitter,
 } from "bee-agent-framework/tools/base";
 import { z } from "zod";
 import { createURLParams } from "bee-agent-framework/internals/fetcher";
 import { RunContext } from "bee-agent-framework/context";
+import { Emitter } from "bee-agent-framework/emitter/emitter";
 
 type ToolOptions = BaseToolOptions & { maxResults?: number };
 type ToolRunOptions = BaseToolRunOptions;
@@ -46,6 +48,12 @@ export class OpenLibraryTool extends Tool<OpenLibraryToolOutput, ToolOptions, To
       })
       .partial();
   }
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, OpenLibraryToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "search", "openLibrary"],
+      creator: this,
+    });
 
   static {
     this.register();

--- a/src/tools/arxiv.ts
+++ b/src/tools/arxiv.ts
@@ -17,6 +17,7 @@
 import {
   BaseToolOptions,
   BaseToolRunOptions,
+  CustomToolEmitter,
   JSONToolOutput,
   Tool,
   ToolError,
@@ -33,6 +34,7 @@ import { castArray } from "@/internals/helpers/array.js";
 import { ValueOf } from "@/internals/types.js";
 import { AnyToolSchemaLike } from "@/internals/helpers/schema.js";
 import { RunContext } from "@/context.js";
+import { Emitter } from "@/emitter/emitter.js";
 
 type ToolOptions = BaseToolOptions;
 type ToolRunOptions = BaseToolRunOptions;
@@ -111,6 +113,13 @@ const extractId = (value: string) =>
 export class ArXivTool extends Tool<ArXivToolOutput, ToolOptions, ToolRunOptions> {
   name = "ArXiv";
   description = `Retrieves research articles published on arXiv including related metadata.`;
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, ArXivToolOutput> = Emitter.root.child(
+    {
+      namespace: ["tool", "search", "arxiv"],
+      creator: this,
+    },
+  );
 
   @Cache()
   inputSchema() {

--- a/src/tools/base.test.ts
+++ b/src/tools/base.test.ts
@@ -17,6 +17,7 @@
 import {
   BaseToolOptions,
   BaseToolRunOptions,
+  CustomToolEmitter,
   DynamicTool,
   JSONToolOutput,
   StringToolOutput,
@@ -32,6 +33,7 @@ import { z } from "zod";
 import { SlidingCache } from "@/cache/slidingCache.js";
 import { Serializer } from "@/serializer/serializer.js";
 import { verifyDeserialization } from "@tests/e2e/utils.js";
+import { Emitter } from "@/emitter/emitter.js";
 
 describe("Base Tool", () => {
   beforeEach(() => {
@@ -44,6 +46,10 @@ describe("Base Tool", () => {
     class DummyTool extends Tool<StringToolOutput> {
       name = "DummyTool";
       description = "DummyTool description";
+      emitter: CustomToolEmitter<ToolInput<this>, StringToolOutput> = Emitter.root.child({
+        namespace: ["tool", "dummy"],
+        creator: this,
+      });
 
       inputSchema() {
         return z.object({ query: z.string() });
@@ -300,6 +306,7 @@ describe("Base Tool", () => {
     class ComplexTool extends Tool<StringToolOutput> {
       name = "ComplexTool";
       description = "ComplexTool description";
+      emitter = Emitter.root.child<any>({});
 
       inputSchema() {
         return z.object({ foo: z.string(), bar: z.string() });
@@ -538,27 +545,27 @@ describe("Base Tool", () => {
         [
           {
             "data": "null",
-            "event": "tool.run.start",
+            "event": "tool.dummy.run.start",
           },
           {
             "data": "{"input":{"query":"Hello!"}}",
-            "event": "tool.start",
+            "event": "tool.dummy.start",
           },
           {
             "data": "{"output":{"result":"Hey!"},"input":{"query":"Hello!"}}",
-            "event": "tool.success",
+            "event": "tool.dummy.success",
           },
           {
             "data": "null",
-            "event": "tool.finish",
+            "event": "tool.dummy.finish",
           },
           {
             "data": "{"result":"Hey!"}",
-            "event": "tool.run.success",
+            "event": "tool.dummy.run.success",
           },
           {
             "data": "null",
-            "event": "tool.run.finish",
+            "event": "tool.dummy.run.finish",
           },
         ]
       `);

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -39,7 +39,7 @@ import { GetRunContext, RunContext } from "@/context.js";
 import { shallowCopy } from "@/serializer/utils.js";
 import { INSTRUMENTATION_ENABLED } from "@/instrumentation/config.js";
 import { createTelemetryMiddleware } from "@/instrumentation/create-telemetry-middleware.js";
-import { doNothing } from "remeda";
+import { doNothing, toCamelCase } from "remeda";
 
 export class ToolError extends FrameworkError {}
 
@@ -161,13 +161,22 @@ export type ToolInputRaw<T extends AnyTool> = FromSchemaLikeRaw<
 type ToolConstructorParameters<TOptions extends BaseToolOptions> =
   Partial<TOptions> extends TOptions ? [options?: TOptions] : [options: TOptions];
 
-export interface ToolCallbacks<TInput, TOutput> {
+export interface ToolEvents<
+  TInput extends Record<string, any> = Record<string, any>,
+  TOutput extends ToolOutput = ToolOutput,
+> {
   start: Callback<{ input: TInput; options: unknown }>;
   success: Callback<{ output: TOutput; input: TInput; options: unknown }>;
   error: Callback<{ input: TInput; error: ToolError | ToolInputValidationError; options: unknown }>;
   retry: Callback<{ error: ToolError | ToolInputValidationError; input: TInput; options: unknown }>;
   finish: Callback<null>;
 }
+
+export type CustomToolEmitter<
+  A extends Record<string, any>,
+  B extends ToolOutput,
+  C = Record<never, never>,
+> = Emitter<ToolEvents<A, B> & Omit<C, keyof ToolEvents>>;
 
 export abstract class Tool<
   TOutput extends ToolOutput = ToolOutput,
@@ -180,10 +189,7 @@ export abstract class Tool<
   public readonly cache: BaseCache<Task<TOutput>>;
   public readonly options: TOptions;
 
-  public readonly emitter = Emitter.root.child<ToolCallbacks<ToolInput<this>, TOutput>>({
-    namespace: ["tool"],
-    creator: this,
-  });
+  public abstract readonly emitter: Emitter<ToolEvents<any, TOutput>>;
 
   abstract inputSchema(): Promise<AnyToolSchemaLike> | AnyToolSchemaLike;
 
@@ -452,6 +458,7 @@ export class DynamicTool<
   declare name: string;
   declare description: string;
   private readonly _inputSchema: TInputSchema;
+  declare readonly emitter: Emitter<ToolEvents<FromSchemaLike<TInputSchema>, TOutput>>;
   private readonly handler;
 
   inputSchema(): TInputSchema {
@@ -492,6 +499,10 @@ export class DynamicTool<
     this.description = fields.description;
     this._inputSchema = fields.inputSchema;
     this.handler = fields.handler;
+    this.emitter = Emitter.root.child({
+      namespace: ["tool", "dynamic", toCamelCase(this.name)],
+      creator: this,
+    });
   }
 
   protected _run(

--- a/src/tools/calculator.ts
+++ b/src/tools/calculator.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { StringToolOutput, Tool, ToolInput } from "@/tools/base.js";
+import { CustomToolEmitter, StringToolOutput, Tool, ToolInput } from "@/tools/base.js";
 import { z } from "zod";
 import { create, all, evaluate, ImportOptions, ImportObject, ConfigOptions } from "mathjs";
+import { Emitter } from "@/emitter/emitter.js";
 
 export interface CalculatorToolInput {
   config?: ConfigOptions;
@@ -37,6 +38,12 @@ export class CalculatorTool extends Tool<StringToolOutput> {
   name = "Calculator";
   description = `A calculator tool that performs basic arithmetic operations like addition, subtraction, multiplication, and division. 
 Only use the calculator tool if you need to perform a calculation.`;
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, StringToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "calculator"],
+      creator: this,
+    });
 
   inputSchema() {
     return z.object({

--- a/src/tools/custom.ts
+++ b/src/tools/custom.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { BaseToolOptions, BaseToolRunOptions, StringToolOutput, Tool } from "@/tools/base.js";
+import {
+  BaseToolOptions,
+  BaseToolRunOptions,
+  CustomToolEmitter,
+  StringToolOutput,
+  Tool,
+  ToolInput,
+} from "@/tools/base.js";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { PromiseClient, createPromiseClient } from "@connectrpc/connect";
 import { FrameworkError } from "@/errors.js";
@@ -23,6 +30,7 @@ import { validate } from "@/internals/helpers/general.js";
 import { CodeInterpreterService } from "bee-proto/code_interpreter/v1/code_interpreter_service_connect";
 import { CodeInterpreterOptions } from "./python/python.js";
 import { RunContext } from "@/context.js";
+import { Emitter } from "@/emitter/emitter.js";
 
 export class CustomToolCreateError extends FrameworkError {}
 export class CustomToolExecuteError extends FrameworkError {}
@@ -57,6 +65,12 @@ function createCodeInterpreterClient(codeInterpreter: CodeInterpreterOptions) {
 export class CustomTool extends Tool<StringToolOutput, CustomToolOptions> {
   name: string;
   description: string;
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, StringToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "custom"],
+      creator: this,
+    });
 
   public inputSchema() {
     return this.options.inputSchema;

--- a/src/tools/database/elasticsearch.ts
+++ b/src/tools/database/elasticsearch.ts
@@ -22,6 +22,7 @@ import {
   BaseToolRunOptions,
   JSONToolOutput,
   ToolInputValidationError,
+  CustomToolEmitter,
 } from "@/tools/base.js";
 import { Cache } from "@/cache/decoratorCache.js";
 import { RunContext } from "@/context.js";
@@ -30,6 +31,7 @@ import { ValidationError } from "ajv";
 import { AnyToolSchemaLike } from "@/internals/helpers/schema.js";
 import { parseBrokenJson } from "@/internals/helpers/schema.js";
 import { Client, ClientOptions, estypes as ESTypes } from "@elastic/elasticsearch";
+import { Emitter } from "@/emitter/emitter.js";
 
 export interface ElasticSearchToolOptions extends BaseToolOptions {
   connection: ClientOptions;
@@ -95,6 +97,14 @@ export class ElasticSearchTool extends Tool<
         .describe("How many records will be retrieved from the ElasticSearch query. Maximum is 10"),
     });
   }
+
+  public readonly emitter: CustomToolEmitter<
+    ToolInput<this>,
+    JSONToolOutput<ElasticSearchToolResult>
+  > = Emitter.root.child({
+    namespace: ["tool", "database", "elasticsearch"],
+    creator: this,
+  });
 
   protected validateInput(
     schema: AnyToolSchemaLike,

--- a/src/tools/database/milvus.ts
+++ b/src/tools/database/milvus.ts
@@ -22,6 +22,7 @@ import {
   BaseToolRunOptions,
   JSONToolOutput,
   ToolInputValidationError,
+  CustomToolEmitter,
 } from "@/tools/base.js";
 import { Cache } from "@/cache/decoratorCache.js";
 import { AnyToolSchemaLike } from "@/internals/helpers/schema.js";
@@ -33,6 +34,7 @@ import {
   DescribeCollectionResponse,
 } from "@zilliz/milvus2-sdk-node";
 import { z } from "zod";
+import { Emitter } from "@/emitter/emitter.js";
 
 export interface MilvusToolOptions extends BaseToolOptions {
   connection: ClientConfig;
@@ -113,6 +115,14 @@ export class MilvusDatabaseTool extends Tool<
         .describe(`Fields to return in search results for ${MilvusAction.Search}`),
     });
   }
+
+  public readonly emitter: CustomToolEmitter<
+    ToolInput<this>,
+    JSONToolOutput<MilvusSearchToolResult>
+  > = Emitter.root.child({
+    namespace: ["tool", "database", "milvus"],
+    creator: this,
+  });
 
   protected validateInput(
     schema: AnyToolSchemaLike,

--- a/src/tools/llm.ts
+++ b/src/tools/llm.ts
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import { BaseToolOptions, StringToolOutput, Tool, ToolInput } from "@/tools/base.js";
+import {
+  BaseToolOptions,
+  CustomToolEmitter,
+  StringToolOutput,
+  Tool,
+  ToolInput,
+} from "@/tools/base.js";
 import { AnyLLM, GenerateOptions } from "@/llms/base.js";
 import { z } from "zod";
+import { Emitter } from "@/emitter/emitter.js";
 
 export type LLMToolInput = string;
 
@@ -41,6 +48,12 @@ export class LLMTool<T> extends Tool<StringToolOutput, LLMToolOptions<T>, LLMToo
   inputSchema() {
     return z.object({ input: z.string() });
   }
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, StringToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "llm"],
+      creator: this,
+    });
 
   static {
     this.register();

--- a/src/tools/python/python.ts
+++ b/src/tools/python/python.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { BaseToolOptions, BaseToolRunOptions, Tool, ToolInput } from "@/tools/base.js";
+import {
+  BaseToolOptions,
+  BaseToolRunOptions,
+  CustomToolEmitter,
+  Tool,
+  ToolInput,
+} from "@/tools/base.js";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { PromiseClient, createPromiseClient } from "@connectrpc/connect";
 import { CodeInterpreterService } from "bee-proto/code_interpreter/v1/code_interpreter_service_connect";
@@ -29,6 +35,7 @@ import { ValidationError } from "ajv";
 import { ConnectionOptions } from "node:tls";
 import { RunContext } from "@/context.js";
 import { hasMinLength } from "@/internals/helpers/array.js";
+import { Emitter } from "@/emitter/emitter.js";
 
 export interface CodeInterpreterOptions {
   url: string;
@@ -70,6 +77,12 @@ export class PythonTool extends Tool<PythonToolOutput, PythonToolOptions> {
 
   public readonly storage: PythonStorage;
   protected files: PythonFile[] = [];
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, PythonToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "python"],
+      creator: this,
+    });
 
   async inputSchema() {
     this.files = await this.storage.list();

--- a/src/tools/search/duckDuckGoSearch.ts
+++ b/src/tools/search/duckDuckGoSearch.ts
@@ -23,13 +23,14 @@ import {
   SearchToolResult,
   SearchToolRunOptions,
 } from "./base.js";
-import { Tool, ToolInput } from "@/tools/base.js";
+import { CustomToolEmitter, Tool, ToolInput } from "@/tools/base.js";
 import { HeaderGenerator } from "header-generator";
 import type { NeedleOptions } from "needle";
 import { z } from "zod";
 import { Cache } from "@/cache/decoratorCache.js";
 import { RunContext } from "@/context.js";
 import { paginate } from "@/internals/helpers/paginate.js";
+import { Emitter } from "@/emitter/emitter.js";
 
 export { SafeSearchType as DuckDuckGoSearchToolSearchType };
 
@@ -75,6 +76,12 @@ export class DuckDuckGoSearchTool extends Tool<
   name = "DuckDuckGo";
   description =
     "Search for online trends, news, current events, real-time information, or research topics.";
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, DuckDuckGoSearchToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "search", "ddg"],
+      creator: this,
+    });
 
   protected readonly client: typeof rawDDGSearch;
 

--- a/src/tools/search/googleSearch.ts
+++ b/src/tools/search/googleSearch.ts
@@ -21,7 +21,7 @@ import {
   SearchToolResult,
   SearchToolRunOptions,
 } from "./base.js";
-import { Tool, ToolInput } from "@/tools/base.js";
+import { CustomToolEmitter, Tool, ToolInput } from "@/tools/base.js";
 import { z } from "zod";
 import { Cache } from "@/cache/decoratorCache.js";
 import { ValueError } from "@/errors.js";
@@ -29,6 +29,7 @@ import { parseEnv } from "@/internals/env.js";
 import { RunContext } from "@/context.js";
 import { paginate } from "@/internals/helpers/paginate.js";
 import { ValidationError } from "ajv";
+import { Emitter } from "@/emitter/emitter.js";
 
 export interface GoogleSearchToolOptions extends SearchToolOptions {
   apiKey?: string;
@@ -67,6 +68,12 @@ export class GoogleSearchTool extends Tool<
 > {
   name = "GoogleSearch";
   description = `Search for online trends, news, current events, real-time information, or research topics.`;
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, GoogleSearchToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "search", "google"],
+      creator: this,
+    });
 
   @Cache()
   inputSchema() {

--- a/src/tools/search/wikipedia.ts
+++ b/src/tools/search/wikipedia.ts
@@ -27,13 +27,14 @@ import {
 } from "./base.js";
 import { asyncProperties } from "@/internals/helpers/promise.js";
 import { z } from "zod";
-import { Tool, ToolInput } from "@/tools/base.js";
+import { CustomToolEmitter, Tool, ToolInput } from "@/tools/base.js";
 import Turndown from "turndown";
 // @ts-expect-error missing types
 import turndownPlugin from "joplin-turndown-plugin-gfm";
 import { keys, mapValues } from "remeda";
 import stringComparison from "string-comparison";
 import { pageResult } from "wikipedia/dist/resultTypes.js";
+import { Emitter } from "@/emitter/emitter.js";
 
 wiki.default.setLang("en");
 
@@ -134,6 +135,12 @@ export class WikipediaTool extends Tool<
   name = "Wikipedia";
   description =
     "Search factual and historical information, including biography, history, politics, geography, society, culture, science, technology, people, animal species, mathematics, and other subjects.";
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, WikipediaToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "search", "wikipedia"],
+      creator: this,
+    });
 
   inputSchema() {
     return z.object({

--- a/src/tools/similarity.ts
+++ b/src/tools/similarity.ts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-import { BaseToolOptions, BaseToolRunOptions, JSONToolOutput, Tool, ToolInput } from "./base.js";
+import {
+  BaseToolOptions,
+  BaseToolRunOptions,
+  CustomToolEmitter,
+  JSONToolOutput,
+  Tool,
+  ToolInput,
+} from "./base.js";
 import { string, z } from "zod";
 import { RunContext } from "@/context.js";
 import { map, pipe, prop, sortBy, take } from "remeda";
+import { Emitter } from "@/emitter/emitter.js";
 
 const documentSchema = z.object({ text: string() }).passthrough();
 
@@ -59,6 +67,12 @@ export class SimilarityTool<TProviderOptions> extends Tool<
 > {
   name = "Similarity";
   description = "Extract relevant information from documents.";
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, SimilarityToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "similarity"],
+      creator: this,
+    });
 
   inputSchema() {
     return z.object({ query: z.string(), documents: z.array(documentSchema) });

--- a/src/tools/web/webCrawler.ts
+++ b/src/tools/web/webCrawler.ts
@@ -17,6 +17,7 @@
 import {
   BaseToolOptions,
   BaseToolRunOptions,
+  CustomToolEmitter,
   JSONToolOutput,
   Tool,
   ToolInput,
@@ -25,6 +26,7 @@ import { z } from "zod";
 import { Cache } from "@/cache/decoratorCache.js";
 import { stripHtml } from "string-strip-html";
 import { RunContext } from "@/context.js";
+import { Emitter } from "@/emitter/emitter.js";
 
 interface CrawlerOutput {
   url: string;
@@ -83,6 +85,12 @@ export class WebCrawlerTool extends Tool<WebCrawlerToolOutput, WebsiteCrawlerToo
 
   protected client: HttpClient;
   protected parser: Parser;
+
+  public readonly emitter: CustomToolEmitter<ToolInput<this>, WebCrawlerToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "webCrawler"],
+      creator: this,
+    });
 
   constructor({ client, parser, ...options }: WebsiteCrawlerToolOptions = {}) {
     super(options);


### PR DESCRIPTION
- Tools' base events are now typed and can be easily extended (this was not previously possible due to TS errors).
- Each tool will now has its own namespace instead of a default one.

⚠️ Breaking changes due to TS limitations.

- Emitter now must be defined manually for all new tools (base tool defines emitter as abstract).