### PR TITLE
fix: provide correct model id for granite vllm

### DIFF
--- a/examples/agents/ibm_granite_bee.ts
+++ b/examples/agents/ibm_granite_bee.ts
@@ -45,7 +45,7 @@ function getChatLLM(provider?: Provider): ChatLLM<ChatLLMOutput> {
         projectId: getEnv("WATSONX_PROJECT_ID"),
         region: getEnv("WATSONX_REGION"),
       }),
-    [Providers.IBMVLLM]: () => IBMVllmChatLLM.fromPreset(IBMVllmModel.GRANITE_INSTRUCT),
+    [Providers.IBMVLLM]: () => IBMVllmChatLLM.fromPreset(IBMVllmModel.GRANITE_3_0_8B_INSTRUCT),
     [Providers.IBMRITS]: () =>
       new OpenAIChatLLM({
         client: new OpenAI({

--- a/src/adapters/ibm-vllm/chatPreset.ts
+++ b/src/adapters/ibm-vllm/chatPreset.ts
@@ -27,7 +27,7 @@ export const IBMVllmModel = {
   LLAMA_3_1_405B_INSTRUCT_FP8: "meta-llama/llama-3-1-405b-instruct-fp8",
   LLAMA_3_1_70B_INSTRUCT: "meta-llama/llama-3-1-70b-instruct",
   LLAMA_3_1_8B_INSTRUCT: "meta-llama/llama-3-1-8b-instruct",
-  GRANITE_INSTRUCT: "ibm/granite-instruct", // Generic model ID is used for ease of development, ground it once stable
+  GRANITE_3_0_8B_INSTRUCT: "ibm-granite/granite-3.0-8b-instruct",
 } as const;
 export type IBMVllmModel = (typeof IBMVllmModel)[keyof typeof IBMVllmModel];
 
@@ -95,11 +95,11 @@ export const IBMVllmChatLLMPreset = {
       },
     };
   },
-  [IBMVllmModel.GRANITE_INSTRUCT]: (): IBMVllmChatLLMPreset => {
+  [IBMVllmModel.GRANITE_3_0_8B_INSTRUCT]: (): IBMVllmChatLLMPreset => {
     const { template, parameters, messagesToPrompt } = LLMChatTemplates.get("granite3Instruct");
     return {
       base: {
-        modelId: IBMVllmModel.GRANITE_INSTRUCT,
+        modelId: IBMVllmModel.GRANITE_3_0_8B_INSTRUCT,
         parameters: {
           method: "GREEDY",
           stopping: {


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: #190 

### Description

The backend ibmvllm model for granite has been updated to `ibm-granite/granite-3.0-8b-instruct` but retains the generic name `ibm/granite-instruct`. 

Thie fix corrects the name in the ibmvllm adapter.  

### Checklist

<!-- For completed items, change [ ] to [x]. -->
- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)