### PR TITLE
fix(agents): broaden the granite runner check

### DIFF
--- a/src/agents/bee/agent.ts
+++ b/src/agents/bee/agent.ts
@@ -65,7 +65,7 @@ export class BeeAgent extends BaseAgent<BeeRunInput, BeeRunOutput, BeeRunOptions
       );
     }
 
-    this.runner = this.input.llm.modelId.includes("ibm/granite") ? GraniteRunner : DefaultRunner;
+    this.runner = this.input.llm.modelId.includes("granite") ? GraniteRunner : DefaultRunner;
   }
 
   static {


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: #216 

### Description
Broadens the granite runner check to capture ollama model ids.
I worked on a more specific regex but ultimately I think a simple check for `granite` is simple, and sufficient until we determine that it isn't. 


### Checklist
- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
