### PR TITLE
fix(llms): correct the vllm granite model_id

### DIFF
--- a/src/adapters/ibm-vllm/chatPreset.ts
+++ b/src/adapters/ibm-vllm/chatPreset.ts
@@ -27,7 +27,7 @@ export const IBMVllmModel = {
   LLAMA_3_1_405B_INSTRUCT_FP8: "meta-llama/llama-3-1-405b-instruct-fp8",
   LLAMA_3_1_70B_INSTRUCT: "meta-llama/llama-3-1-70b-instruct",
   LLAMA_3_1_8B_INSTRUCT: "meta-llama/llama-3-1-8b-instruct",
-  GRANITE_3_0_8B_INSTRUCT: "ibm-granite/granite-3.0-8b-instruct",
+  GRANITE_3_0_8B_INSTRUCT: "ibm-granite/granite-3-0-8b-instruct",
 } as const;
 export type IBMVllmModel = (typeof IBMVllmModel)[keyof typeof IBMVllmModel];
 


### PR DESCRIPTION
### Which issue(s) does this pull-request address?
Cant have a (dot) in ibmvllm backend model id, so the current ibmvllm model_id for granite is incorrect due to the inclusion of a (dot).

### Description
- Replaced the (dot) with a dash to match the backend model id. 

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
