### PR TITLE
revert(agents): update constrained decoding for Bee

### DIFF
--- a/src/agents/bee/runners/default/runner.ts
+++ b/src/agents/bee/runners/default/runner.ts
@@ -363,7 +363,7 @@ export class DefaultRunner extends BaseRunner {
     const parserRegex = isEmpty(tools)
       ? new RegExp(`Thought: .+\\nFinal Answer: [\\s\\S]+`)
       : new RegExp(
-          `Thought: .+\\n(?:Final Answer: [\\s\\S]+|Function Name: (${tools.map((tool) => tool.name).join("|")})\\nFunction Input: \\{.*\\}\\nFunction Output:)?`,
+          `Thought: .+\\n(?:Final Answer: [\\s\\S]+|Function Name: (${tools.map((tool) => tool.name).join("|")})\\nFunction Input: \\{.*\\}\\nFunction Output:)`,
         );
 
     const parser = new LinePrefixParser<BeeParserInput>(

--- a/src/agents/bee/runners/default/runner.ts
+++ b/src/agents/bee/runners/default/runner.ts
@@ -363,7 +363,7 @@ export class DefaultRunner extends BaseRunner {
     const parserRegex = isEmpty(tools)
       ? new RegExp(`Thought: .+\\nFinal Answer: [\\s\\S]+`)
       : new RegExp(
-          `Thought: (?!.*Function Name:).+\\n(?:Final Answer: [\\s\\S]+|Function Name: (?:${tools.map((tool) => tool.name).join("|")})\\nFunction Input: \\{.*\\}\\nFunction Output:)`,
+          `Thought: .+\\n(?:Final Answer: [\\s\\S]+|Function Name: (${tools.map((tool) => tool.name).join("|")})\\nFunction Input: \\{.*\\}\\nFunction Output:)?`,
         );
 
     const parser = new LinePrefixParser<BeeParserInput>(

--- a/src/agents/bee/runners/granite/runner.ts
+++ b/src/agents/bee/runners/granite/runner.ts
@@ -90,7 +90,7 @@ export class GraniteRunner extends DefaultRunner {
       parserRegex: isEmpty(tools)
         ? new RegExp(`Thought: .+\\nFinal Answer: [\\s\\S]+`)
         : new RegExp(
-            `Thought: .+\\n(?:Final Answer: [\\s\\S]+|Tool Name: (${tools.map((tool) => tool.name).join("|")})\\nTool Input: \\{.*\\})?`,
+            `Thought: .+\\n(?:Final Answer: [\\s\\S]+|Tool Name: (${tools.map((tool) => tool.name).join("|")})\\nTool Input: \\{.*\\})`,
           ),
       parser: parser.fork<BeeParserInput>((nodes, options) => ({
         options,

--- a/src/agents/bee/runners/granite/runner.ts
+++ b/src/agents/bee/runners/granite/runner.ts
@@ -90,7 +90,7 @@ export class GraniteRunner extends DefaultRunner {
       parserRegex: isEmpty(tools)
         ? new RegExp(`Thought: .+\\nFinal Answer: [\\s\\S]+`)
         : new RegExp(
-            `Thought: (?!.*Tool Name:).+\\n(?:Final Answer: [\\s\\S]+|Tool Name: (?:${tools.map((tool) => tool.name).join("|")})\\nTool Input: \\{.*\\})`,
+            `Thought: .+\\n(?:Final Answer: [\\s\\S]+|Tool Name: (${tools.map((tool) => tool.name).join("|")})\\nTool Input: \\{.*\\})?`,
           ),
       parser: parser.fork<BeeParserInput>((nodes, options) => ({
         options,


### PR DESCRIPTION

### Which issue(s) does this pull-request address?

N/A

### Description

Reverts 41ea34f commit that introduced changes to constrained decoding that have negative impact on inference speed. It keeps whitespaces in place.

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [ ] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
