### PR TITLE
feat(agents): extend bee start event

### DIFF
--- a/src/agents/bee/runners/default/runner.ts
+++ b/src/agents/bee/runners/default/runner.ts
@@ -85,9 +85,10 @@ export class DefaultRunner extends BaseRunner {
         }
       },
       executor: async () => {
-        await emitter.emit("start", { meta });
+        const tools = this.input.tools.slice();
+        await emitter.emit("start", { meta, tools, memory: this.memory });
 
-        const { parser, parserRegex } = this.createParser(this.input.tools);
+        const { parser, parserRegex } = this.createParser(tools);
         const llmOutput = await this.input.llm
           .generate(this.memory.messages.slice(), {
             signal,

--- a/src/agents/bee/runners/default/runner.ts
+++ b/src/agents/bee/runners/default/runner.ts
@@ -44,6 +44,7 @@ import { TokenMemory } from "@/memory/tokenMemory.js";
 import { getProp } from "@/internals/helpers/object.js";
 import { BaseMemory } from "@/memory/base.js";
 import { Cache } from "@/cache/decoratorCache.js";
+import { shallowCopy } from "@/serializer/utils.js";
 
 export class DefaultRunner extends BaseRunner {
   static {
@@ -185,24 +186,26 @@ export class DefaultRunner extends BaseRunner {
         this.failedAttemptsCounter.use(error);
       },
       executor: async () => {
+        const toolOptions = shallowCopy(this.options);
+
         try {
           await emitter.emit("toolStart", {
             data: {
               tool,
               input: state.tool_input,
-              options: this.options,
+              options: toolOptions,
               iteration: state,
             },
             meta,
           });
-          const toolOutput: ToolOutput = await tool.run(state.tool_input, this.options).context({
+          const toolOutput: ToolOutput = await tool.run(state.tool_input, toolOptions).context({
             [Tool.contextKeys.Memory]: this.memory,
           });
           await emitter.emit("toolSuccess", {
             data: {
               tool,
               input: state.tool_input,
-              options: this.options,
+              options: toolOptions,
               result: toolOutput,
               iteration: state,
             },
@@ -222,7 +225,7 @@ export class DefaultRunner extends BaseRunner {
             data: {
               tool,
               input: state.tool_input,
-              options: this.options,
+              options: toolOptions,
               error,
               iteration: state,
             },

--- a/src/agents/bee/types.ts
+++ b/src/agents/bee/types.ts
@@ -69,7 +69,7 @@ export interface BeeUpdateMeta extends BeeMeta {
 }
 
 export interface BeeCallbacks {
-  start?: Callback<{ meta: BeeMeta }>;
+  start?: Callback<{ meta: BeeMeta; tools: AnyTool[]; memory: BaseMemory }>;
   error?: Callback<{ error: Error; meta: BeeMeta }>;
   retry?: Callback<{ meta: BeeMeta }>;
   success?: Callback<{


### PR DESCRIPTION
Extends the Bee 'start' event to allow on-fly modifications.

Usage:

```typescript
const agent = new BeeAgent(...)

agent.emitter.on("start", async ({ memory, tools, meta }) => {
  console.log(`Iteration: ${meta.iteration}`);
  const lastMessage = memory.messages.at(-1);
  if (lastMessage?.text.includes("weather")) {
    tools.splice(0, Infinity, ...tools.filter((tool) => tool.name.includes("weather")));
  }
});
```

Ref: #184
