### PR TITLE
feat: (instrumentation): increase timestamp precision

### DIFF
--- a/src/instrumentation/create-telemetry-middleware.ts
+++ b/src/instrumentation/create-telemetry-middleware.ts
@@ -82,7 +82,12 @@ export function createTelemetryMiddleware() {
 
     const eventsIterationsMap = new Map<string, Map<string, string>>();
 
-    const startTime = performance.now();
+    const startTimeDate = new Date().getTime();
+    const startTimePerf = performance.now();
+    function convertDateToPerformance(date: Date) {
+      return date.getTime() - startTimeDate + startTimePerf;
+    }
+
     const serializer = traceSerializer({ ignored_keys: INSTRUMENTATION_IGNORED_KEYS });
 
     function cleanSpanSources({ spanId }: { spanId: string }) {
@@ -140,7 +145,7 @@ export function createTelemetryMiddleware() {
             traceId,
             version: Version,
             runErrorSpanKey: `${basePath}.run.${errorEventName}`,
-            startTime,
+            startTime: startTimePerf,
             endTime: performance.now(),
             source: activeTracesMap.get(traceId)!,
           });
@@ -180,7 +185,7 @@ export function createTelemetryMiddleware() {
             id: meta.groupId,
             name: meta.groupId,
             target: "groupId",
-            startedAt: meta.createdAt,
+            startedAt: convertDateToPerformance(meta.createdAt),
           }),
         );
         groupIterations.push(meta.groupId);
@@ -209,7 +214,7 @@ export function createTelemetryMiddleware() {
         ctx: getSerializedObjectSafe(meta.context),
         data: serializedData,
         error: getErrorSafe(data),
-        startedAt: meta.createdAt,
+        startedAt: convertDateToPerformance(meta.createdAt),
       });
 
       const lastIteration = groupIterations[groupIterations.length - 1];
@@ -296,7 +301,7 @@ export function createTelemetryMiddleware() {
               id: spanId,
               name: `${meta.name}Custom`,
               target: path,
-              startedAt: meta.createdAt,
+              startedAt: convertDateToPerformance(meta.createdAt),
               ...(parentSpanId && { parent: { id: parentSpanId } }),
               data: {
                 rawPrompt,

--- a/src/instrumentation/helpers/create-span.ts
+++ b/src/instrumentation/helpers/create-span.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SpanStatusCode } from "@opentelemetry/api";
+import { SpanStatusCode, TimeInput } from "@opentelemetry/api";
 import { FrameworkSpan } from "@/instrumentation/types.js";
 import { isEmpty } from "remeda";
 
@@ -22,7 +22,7 @@ interface CreateSpanProps {
   id: string;
   name: string;
   target: string;
-  startedAt: Date;
+  startedAt: TimeInput;
   ctx?: any;
   data?: any;
   error?: string;
@@ -55,6 +55,6 @@ export function createSpan({
       message: error ? error : "",
     },
     start_time: startedAt,
-    end_time: new Date(),
+    end_time: performance.now(),
   };
 }


### PR DESCRIPTION

### Description

I increased the span's timestamp precision. The OpenTelemetry framework does not parse the Date objects correctly. 

The code is tested in the API and UI. 

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
