### PR TITLE
feat(llms): add ollama structured output support

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "@zilliz/milvus2-sdk-node": "^2.4.9",
     "google-auth-library": "*",
     "groq-sdk": "^0.7.0",
-    "ollama": "^0.5.8",
+    "ollama": "^0.5.11",
     "openai": "^4.67.3",
     "openai-chat-tokens": "^0.2.8",
     "sequelize": "^6.37.3"
@@ -305,7 +305,7 @@
     "langchain": "~0.3.6",
     "linkinator": "^6.1.2",
     "lint-staged": "^15.2.10",
-    "ollama": "^0.5.10",
+    "ollama": "^0.5.11",
     "openai": "^4.76.0",
     "openai-chat-tokens": "^0.2.8",
     "openapi-fetch": "^0.13.3",

--- a/src/adapters/ollama/llm.ts
+++ b/src/adapters/ollama/llm.ts
@@ -27,14 +27,25 @@ import {
   LLMOutputError,
   StreamGenerateOptions,
 } from "@/llms/base.js";
-import { GenerateRequest, GenerateResponse, Ollama as Client, Options as Parameters } from "ollama";
+import {
+  Config,
+  GenerateRequest,
+  GenerateResponse,
+  Ollama as Client,
+  Options as Parameters,
+} from "ollama";
 import { GetRunContext } from "@/context.js";
 import { Cache } from "@/cache/decoratorCache.js";
 import { safeSum } from "@/internals/helpers/number.js";
 import { shallowCopy } from "@/serializer/utils.js";
 import { signalRace } from "@/internals/helpers/promise.js";
-import { customMerge } from "@/internals/helpers/object.js";
-import { extractModelMeta, registerClient } from "@/adapters/ollama/shared.js";
+import { customMerge, getPropStrict } from "@/internals/helpers/object.js";
+import {
+  extractModelMeta,
+  registerClient,
+  retrieveFormat,
+  retrieveVersion,
+} from "@/adapters/ollama/shared.js";
 import { getEnv } from "@/internals/env.js";
 
 interface Input {
@@ -131,9 +142,9 @@ export class OllamaLLM extends LLM<OllamaLLMOutput> {
     run: GetRunContext<typeof this>,
   ): Promise<OllamaLLMOutput> {
     const response = await signalRace(
-      () =>
+      async () =>
         this.client.generate({
-          ...this.prepareParameters(input, options),
+          ...(await this.prepareParameters(input, options)),
           stream: false,
         }),
       run.signal,
@@ -149,7 +160,7 @@ export class OllamaLLM extends LLM<OllamaLLMOutput> {
     run: GetRunContext<typeof this>,
   ): AsyncStream<OllamaLLMOutput, void> {
     for await (const chunk of await this.client.generate({
-      ...this.prepareParameters(input, options),
+      ...(await this.prepareParameters(input, options)),
       stream: true,
     })) {
       if (run.signal.aborted) {
@@ -158,6 +169,12 @@ export class OllamaLLM extends LLM<OllamaLLMOutput> {
       yield new OllamaLLMOutput(chunk);
     }
     run.signal.throwIfAborted();
+  }
+
+  @Cache()
+  async version() {
+    const config = getPropStrict(this.client, "config") as Config;
+    return retrieveVersion(config.host, config.fetch);
   }
 
   async meta(): Promise<LLMMeta> {
@@ -174,19 +191,16 @@ export class OllamaLLM extends LLM<OllamaLLMOutput> {
     };
   }
 
-  protected prepareParameters(input: LLMInput, overrides?: GenerateOptions): GenerateRequest {
-    const jsonSchema = overrides?.guided?.json;
-
+  protected async prepareParameters(
+    input: LLMInput,
+    overrides?: GenerateOptions,
+  ): Promise<GenerateRequest> {
     return {
       model: this.modelId,
       prompt: input,
       raw: true,
       options: this.parameters,
-      format: jsonSchema
-        ? typeof jsonSchema === "string"
-          ? JSON.parse(jsonSchema)
-          : jsonSchema
-        : undefined,
+      format: retrieveFormat(await this.version(), overrides?.guided),
     };
   }
 

--- a/tests/e2e/adapters/ollama/chat.test.ts
+++ b/tests/e2e/adapters/ollama/chat.test.ts
@@ -19,6 +19,7 @@ import { OllamaChatLLM } from "@/adapters/ollama/chat.js";
 import { Ollama } from "ollama";
 import { toJsonSchema } from "@/internals/helpers/schema.js";
 import { z } from "zod";
+import { Comparator, compareVersion } from "@/internals/helpers/string.js";
 
 const host = process.env.OLLAMA_HOST;
 
@@ -56,6 +57,14 @@ describe.runIf(Boolean(host))("Ollama Chat LLM", () => {
 
   it("Leverages structured output", async () => {
     const llm = createChatLLM();
+    const version = await llm.version();
+
+    if (compareVersion(version, Comparator.LT, "0.5.0")) {
+      // eslint-disable-next-line no-console
+      console.warn(`Structured output is not available in the current version (${version})`);
+      return;
+    }
+
     const response = await llm.generate(
       [
         BaseMessage.of({
@@ -79,5 +88,11 @@ describe.runIf(Boolean(host))("Ollama Chat LLM", () => {
       },
     );
     expect(response.getTextContent()).toMatchInlineSnapshot(`"{"a": "a", "b": "b", "c": "c"}"`);
+  });
+
+  it("Retrieves version", async () => {
+    const llm = createChatLLM();
+    const version = await llm.version();
+    expect(version).toBeDefined();
   });
 });

--- a/tests/e2e/adapters/ollama/test.ts
+++ b/tests/e2e/adapters/ollama/test.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2024 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OllamaChatLLM } from "@/adapters/ollama/chat.js";
+import { Ollama } from "ollama";
+
+const host = process.env.OLLAMA_HOST;
+
+describe.runIf(Boolean(host))("Ollama LLM", () => {
+  const createLLM = () => {
+    return new OllamaChatLLM({
+      modelId: "llama3.1",
+      client: new Ollama({
+        host,
+      }),
+    });
+  };
+
+  it("Retrieves version", async () => {
+    const llm = createLLM();
+    const version = await llm.version();
+    expect(version).toBeDefined();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4845,7 +4845,7 @@ __metadata:
     mathjs: "npm:^14.0.0"
     mustache: "npm:^4.2.0"
     object-hash: "npm:^3.0.0"
-    ollama: "npm:^0.5.10"
+    ollama: "npm:^0.5.11"
     openai: "npm:^4.76.0"
     openai-chat-tokens: "npm:^0.2.8"
     openapi-fetch: "npm:^0.13.3"
@@ -4893,7 +4893,7 @@ __metadata:
     "@zilliz/milvus2-sdk-node": ^2.4.9
     google-auth-library: "*"
     groq-sdk: ^0.7.0
-    ollama: ^0.5.8
+    ollama: ^0.5.11
     openai: ^4.67.3
     openai-chat-tokens: ^0.2.8
     sequelize: ^6.37.3
@@ -10911,12 +10911,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ollama@npm:^0.5.10":
-  version: 0.5.10
-  resolution: "ollama@npm:0.5.10"
+"ollama@npm:^0.5.11":
+  version: 0.5.11
+  resolution: "ollama@npm:0.5.11"
   dependencies:
     whatwg-fetch: "npm:^3.6.20"
-  checksum: 10c0/424b92ef640fb562c590bd8bf394c0cdab3eb93a1b70a58bcb98090957375e05130f41d94578124c0fc79b68448db351e3439e4dc3582ccdb7ae13343951c527
+  checksum: 10c0/9f8bb6715144fac2d423121f29bf7697e3c2132c6696574e2f2de63de8dfa95ac3ed435f3abf35cece6ef07c309065cbf722cead1bee1eda3541b095745f64bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add support for newly introduced Ollama Structured Output.

**TODO: Verify whether the adapter works with Ollama version **below** 0.5 (`ollama --version`)**

```bash
OLLAMA_HOST="http://0.0.0.0:11434" CI=true yarn vitest tests/e2e/adapters/ollama/chat.test.ts
```