### PR TITLE
fix(tools): verify that the end date is later than the start date

### DIFF
--- a/src/tools/weather/openMeteo.ts
+++ b/src/tools/weather/openMeteo.ts
@@ -179,7 +179,7 @@ export class OpenMeteoTool extends Tool<OpenMeteoToolOutput, ToolOptions, ToolRu
           const end = new Date(endDateStr);
           if (end < start) {
             throw new ToolInputValidationError(
-              `The 'end_date' (${endDateStr}) must be occur on or after the 'start_date' (${startDateStr}).`,
+              `The 'end_date' (${endDateStr}) has to occur on or after the 'start_date' (${startDateStr}).`,
             );
           }
           return { start: start, end: end };

--- a/src/tools/weather/openMeteo.ts
+++ b/src/tools/weather/openMeteo.ts
@@ -22,6 +22,7 @@ import {
   Tool,
   ToolError,
   ToolInput,
+  ToolInputValidationError,
 } from "@/tools/base.js";
 import { z } from "zod";
 import { createURLParams } from "@/internals/fetcher.js";
@@ -165,17 +166,30 @@ export class OpenMeteoTool extends Tool<OpenMeteoToolOutput, ToolOptions, ToolRu
         return location;
       };
 
-      const now = new Date();
-      const start = startDate
-        ? new Date(startDate)
-        : new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-      let end = endDate
-        ? new Date(endDate)
-        : new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+      function validateAndSetDates(
+        startDateStr: string,
+        endDateStr?: string,
+      ): { start: Date; end: Date } {
+        const now = new Date();
+        const start = startDateStr
+          ? new Date(startDateStr)
+          : new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
 
-      if (end < start) {
-        end = new Date(start);
+        if (endDateStr) {
+          const end = new Date(endDateStr);
+          if (end < start) {
+            throw new ToolInputValidationError(
+              `The 'end_date' (${endDateStr}) must be occur on or after the 'start_date' (${startDateStr}).`,
+            );
+          }
+          return { start: start, end: end };
+        } else {
+          // If endDate is undefined, set it to the start date
+          return { start: start, end: new Date(start) };
+        }
       }
+
+      const { start, end } = validateAndSetDates(startDate, endDate);
 
       const toDateString = (date: Date) => date.toISOString().split("T")[0];
 

--- a/src/tools/weather/openMeteo.ts
+++ b/src/tools/weather/openMeteo.ts
@@ -169,9 +169,13 @@ export class OpenMeteoTool extends Tool<OpenMeteoToolOutput, ToolOptions, ToolRu
       const start = startDate
         ? new Date(startDate)
         : new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-      const end = endDate
+      let end = endDate
         ? new Date(endDate)
         : new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+
+      if (end < start) {
+        end = new Date(start);
+      }
 
       const toDateString = (date: Date) => date.toISOString().split("T")[0];
 

--- a/tests/e2e/tools/openMeteo.test.ts
+++ b/tests/e2e/tools/openMeteo.test.ts
@@ -134,4 +134,23 @@ describe("OpenMeteo", () => {
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`ToolError: Location 'ABCDEFGH' was not found.`);
   });
+
+  it("Throws on bad end_date < start_date", async () => {
+    await expect(
+      instance.run(
+        {
+          location: {
+            name: "Boston",
+          },
+          start_date: "2024-11-06",
+          end_date: "2024-11-05",
+          temperature_unit: "celsius",
+        },
+        {
+          signal: AbortSignal.timeout(60 * 1000),
+          retryOptions: {},
+        },
+      ),
+    ).rejects.toThrowError(ToolInputValidationError);
+  });
 });


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

If the llm uses the openMeteo tool with a startDate in the future, but does not specify an endDate then the endDate is set to now which is prior to the start date. This causes the the service to throw an error. 

### Description

Check of the end data is prior to the start date, if so reset the end date. 

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
