### PR TITLE
fix(instrumentation): assert raw prompt

### DIFF
--- a/src/instrumentation/helpers/utils.ts
+++ b/src/instrumentation/helpers/utils.ts
@@ -15,12 +15,15 @@
  */
 
 import { BAMChatLLMInputConfig } from "@/adapters/bam/chat.js";
-import { getProp } from "@/internals/helpers/object.js";
 import { BaseLLM } from "@/llms/base.js";
 import { isFunction } from "remeda";
 
 export function assertLLMWithMessagesToPromptFn(instance: object): instance is BaseLLM<any, any> & {
   messagesToPrompt: BAMChatLLMInputConfig["messagesToPrompt"];
 } {
-  return isFunction(getProp(instance, ["messagesToPrompt"])) && instance instanceof BaseLLM;
+  return Boolean(
+    "messagesToPrompt" in instance &&
+      isFunction(instance.messagesToPrompt) &&
+      instance instanceof BaseLLM,
+  );
 }

--- a/src/instrumentation/helpers/utils.ts
+++ b/src/instrumentation/helpers/utils.ts
@@ -22,8 +22,8 @@ export function assertLLMWithMessagesToPromptFn(instance: object): instance is B
   messagesToPrompt: BAMChatLLMInputConfig["messagesToPrompt"];
 } {
   return Boolean(
-    "messagesToPrompt" in instance &&
-      isFunction(instance.messagesToPrompt) &&
-      instance instanceof BaseLLM,
+    instance instanceof BaseLLM &&
+      "messagesToPrompt" in instance &&
+      isFunction(instance.messagesToPrompt),
   );
 }


### PR DESCRIPTION
Closes: https://github.com/i-am-bee/bee-observe/issues/17

### Description

I cannot use `Object.prototype.hasOwnProperty.call` detection in my case, which is used in the `hasProp` function witch is used in the `getProp` function. 

The custom detection is tested and runs well. 

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
