### PR TITLE
feat(instrumentation): trace id for each span

### DIFF
--- a/src/instrumentation/tracer.ts
+++ b/src/instrumentation/tracer.ts
@@ -37,10 +37,11 @@ interface ComputeTreeProps {
 
 interface BuildSpansForParentProps {
   spans: FrameworkSpan[];
+  traceId: string;
   parentId: string | undefined;
 }
 
-function buildSpansForParent({ spans, parentId }: BuildSpansForParentProps) {
+function buildSpansForParent({ spans, parentId, traceId }: BuildSpansForParentProps) {
   spans
     .filter((fwSpan) => fwSpan.parent_id === parentId)
     .forEach((fwSpan) => {
@@ -53,6 +54,7 @@ function buildSpansForParent({ spans, parentId }: BuildSpansForParentProps) {
           attributes: {
             target: fwSpan.attributes.target,
             name: fwSpan.name,
+            traceId,
             ...(fwSpan.attributes.data && { data: JSON.stringify(fwSpan.attributes.data) }),
             ...(fwSpan.attributes.ctx && { ctx: JSON.stringify(fwSpan.attributes.ctx) }),
           },
@@ -62,7 +64,7 @@ function buildSpansForParent({ spans, parentId }: BuildSpansForParentProps) {
           activeSpan.setStatus(fwSpan.status);
 
           // set nested spans
-          buildSpansForParent({ spans, parentId: fwSpan.context.span_id });
+          buildSpansForParent({ spans, traceId, parentId: fwSpan.context.span_id });
 
           // finish the span
           activeSpan.end(fwSpan.end_time);
@@ -107,7 +109,7 @@ export function buildTraceTree({
       }
 
       // set nested spans
-      buildSpansForParent({ spans, parentId: undefined });
+      buildSpansForParent({ spans, traceId, parentId: undefined });
 
       // finish the main span with custom end time
       activeSpan.end(endTime);


### PR DESCRIPTION
### Description

I added the `traceId` attribute to each span. I will use it in the Observe for optimised span loading. 
Must be merged with https://github.com/i-am-bee/bee-observe/pull/25

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/bee-agent-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
